### PR TITLE
Upgraded to latest piston-image

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -5,12 +5,14 @@ use image::{
     Luma,
 };
 
+#[deriving(Copy)]
 pub enum ColorType {
     Grey,
     RGB,
     RGBA,
 }
 
+#[deriving(Copy)]
 pub enum Color {
     RGBA8(Rgba<u8>),
     RGB8(Rgb<u8>),

--- a/src/image_buffer.rs
+++ b/src/image_buffer.rs
@@ -1,7 +1,7 @@
 
 use image;
 use image::{
-    ImageBuf,
+    ImageBuffer,
     ImageRgba8,
     ImageRgb8,
     ImageLuma8,
@@ -16,31 +16,31 @@ use {
     Buffer2d,
 };
 
-pub struct ImageBuffer {
+pub struct ImgBuffer {
     image: DynamicImage,
 }
 
-impl ImageBuffer {
-    pub fn new(w: u32, h: u32, color_type: ColorType) -> ImageBuffer {
-        ImageBuffer {
+impl ImgBuffer {
+    pub fn new(w: u32, h: u32, color_type: ColorType) -> ImgBuffer {
+        ImgBuffer {
             image: match color_type {
                 ColorType::RGBA => {
-                   ImageRgba8(ImageBuf::new(w, h))
+                   ImageRgba8(ImageBuffer::new(w, h))
                 },
                 ColorType::RGB => {
-                    ImageRgb8(ImageBuf::new(w, h))
+                    ImageRgb8(ImageBuffer::new(w, h))
                 },
                 ColorType::Grey => {
-                    ImageLuma8(ImageBuf::new(w, h))
+                    ImageLuma8(ImageBuffer::new(w, h))
                 },
             },
         }
     }
 
-    pub fn open(path: &Path) -> Option<ImageBuffer> {
+    pub fn open(path: &Path) -> Option<ImgBuffer> {
         match image::open(path) {
             Ok(dynimage) => {
-                Some(ImageBuffer {
+                Some(ImgBuffer {
                     image: dynimage,
                 })
             },
@@ -55,7 +55,7 @@ impl ImageBuffer {
     }
 }
 
-impl Buffer2d for ImageBuffer {
+impl Buffer2d for ImgBuffer {
     fn width(&self) -> u32 {
         match self.image.dimensions() {
             (w, _) => { w },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ pub use maxrect_packer::MaxrectPacker;
 pub use skyline_packer::SkylinePacker;
 pub use rect::Rect;
 pub use buffer2d::Buffer2d;
-pub use image_buffer::ImageBuffer;
+pub use image_buffer::ImgBuffer;
 pub use color::{
     ColorType,
     Color,

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -1,5 +1,5 @@
 
-#[deriving(Clone)]
+#[deriving(Copy, Clone)]
 pub struct Rect {
     pub x: u32,
     pub y: u32,


### PR DESCRIPTION
- Renamed to `ImgBuffer` to avoid name collision
- Added missing Copy implementations
