### PR TITLE
add Default trait impl for TexturePackerConfig

### DIFF
--- a/src/texture_packer_config.rs
+++ b/src/texture_packer_config.rs
@@ -1,3 +1,5 @@
+use std::default::Default;
+
 #[derive(Copy, Clone)]
 pub struct TexturePackerConfig {
     //
@@ -18,8 +20,8 @@ pub struct TexturePackerConfig {
     pub texture_outlines: bool,
 }
 
-impl TexturePackerConfig {
-    pub fn default() -> TexturePackerConfig {
+impl Default for TexturePackerConfig {
+    fn default() -> TexturePackerConfig {
         TexturePackerConfig {
             max_width: 1024,
             max_height: 1024,


### PR DESCRIPTION
This adds an implementation of the `Default` trait for `TexturePackerConfig` to follow Rust standard idioms.

Wasn't sure whether the example should be updated to use `Default::default()` instead. It continues to work with `TexturePackerConfig::default()` as I believe `std::default::Default` is one of the traits `use`'d by default.