### PR TITLE
Reexport features of 'image' crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-
 name = "texture_packer"
 version = "0.8.0"
 authors = ["Coeuvre <coeuvre@gmail.com>"]
@@ -11,9 +10,5 @@ repository = "https://github.com/PistonDevelopers/texture_packer.git"
 homepage = "https://github.com/PistonDevelopers/texture_packer"
 documentation = "http://docs.piston.rs/texture_packer"
 
-[lib]
-
-name = "texture_packer"
-
-[dependencies.image]
-version = "0.10.0"
+[dependencies]
+image = "0.10.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,17 @@ repository = "https://github.com/PistonDevelopers/texture_packer.git"
 homepage = "https://github.com/PistonDevelopers/texture_packer"
 documentation = "http://docs.piston.rs/texture_packer"
 
+[features]
+gif_codec = ["image/gif_codec"]
+ico = ["image/ico"]
+jpeg = ["image/jpeg"]
+png_codec = ["image/png_codec"]
+ppm = ["image/ppm"]
+tga = ["image/tga"]
+tiff = ["image/tiff"]
+webp = ["image/webp"]
+bmp = ["image/bmp"]
+hdr = ["image/hdr"]
+
 [dependencies]
-image = "0.10.0"
+image = { version = "0.10.0", default-features = false }


### PR DESCRIPTION
_**NOTE**: This PR breaks the backward compatibility. For earlier discussion, see **https://github.com/PistonDevelopers/texture_packer/issues/45**_

--------

I've tested the compilation time improvement with the command below:

```
cargo rustc -- -Z time-passes
```

##### Before
```
time: 9.335	translation
time: 0.000	assert dep graph
time: 0.000	serialize dep graph
  time: 0.233	llvm function passes [0]
  time: 0.104	llvm module passes [0]
  time: 5.822	codegen passes [0]
  time: 0.001	codegen passes [0]
time: 6.161	LLVM passes
  time: 0.800	running linker
time: 1.571	linking
```

##### After
```
time: 2.771	translation
time: 0.000	assert dep graph
time: 0.000	serialize dep graph
  time: 0.098	llvm function passes [0]
  time: 0.048	llvm module passes [0]
  time: 2.089	codegen passes [0]
  time: 0.000	codegen passes [0]
time: 2.238	LLVM passes
  time: 0.423	running linker
time: 0.993	linking
```

Closes #45