### PR TITLE
packer: Remove the pixel format from the packer

### DIFF
--- a/src/multi_texture_packer.rs
+++ b/src/multi_texture_packer.rs
@@ -14,9 +14,7 @@ pub struct MultiTexturePacker<'a, T: 'a + Clone, P> {
     pages: Vec<TexturePacker<'a, T, P>>,
 }
 
-impl<'a, Pix: Pixel, T: Clone + Texture<Pixel = Pix>, P: Packer<Pixel = Pix>>
-    MultiTexturePacker<'a, T, P>
-{
+impl<'a, Pix: Pixel, T: Clone + Texture<Pixel = Pix>, P: Packer> MultiTexturePacker<'a, T, P> {
     /// Get an array of all underlying single-atlas texture packers.
     pub fn get_pages(&self) -> &[TexturePacker<'a, T, P>] {
         &self.pages
@@ -24,7 +22,7 @@ impl<'a, Pix: Pixel, T: Clone + Texture<Pixel = Pix>, P: Packer<Pixel = Pix>>
 }
 
 impl<'a, Pix: Pixel, T: 'a + Clone + Texture<Pixel = Pix>>
-    MultiTexturePacker<'a, T, SkylinePacker<Pix>>
+    MultiTexturePacker<'a, T, SkylinePacker>
 {
     /// Create a new packer using the skyline packing algorithm.
     pub fn new_skyline(config: TexturePackerConfig) -> Self {
@@ -35,8 +33,8 @@ impl<'a, Pix: Pixel, T: 'a + Clone + Texture<Pixel = Pix>>
     }
 }
 
-impl<'a, Pix: Pixel, T: Clone + Texture<Pixel = Pix>>
-    MultiTexturePacker<'a, T, SkylinePacker<Pix>>
+impl<'a, Pix: Pixel, T: 'a + Clone + Texture<Pixel = Pix>>
+    MultiTexturePacker<'a, T, SkylinePacker>
 {
     /// Pack the `texture` into this packer, taking a reference of the texture object.
     pub fn pack_ref(&mut self, key: String, texture: &'a T) -> PackResult<()> {

--- a/src/packer/mod.rs
+++ b/src/packer/mod.rs
@@ -1,15 +1,10 @@
-use crate::{
-    frame::Frame,
-    texture::{Pixel, Texture},
-};
+use crate::{frame::Frame, rect::Rect};
 
 pub use self::skyline_packer::SkylinePacker;
 
 mod skyline_packer;
 
 pub trait Packer {
-    type Pixel: Pixel;
-
-    fn pack(&mut self, key: String, texture: &dyn Texture<Pixel = Self::Pixel>) -> Option<Frame>;
-    fn can_pack(&self, texture: &dyn Texture<Pixel = Self::Pixel>) -> bool;
+    fn pack(&mut self, key: String, texture_rect: &Rect) -> Option<Frame>;
+    fn can_pack(&self, texture_rect: &Rect) -> bool;
 }

--- a/src/packer/skyline_packer.rs
+++ b/src/packer/skyline_packer.rs
@@ -1,11 +1,5 @@
-use crate::{
-    frame::Frame,
-    packer::Packer,
-    rect::Rect,
-    texture::{Pixel, Texture},
-    texture_packer_config::TexturePackerConfig,
-};
-use std::{cmp::max, marker::PhantomData};
+use crate::{frame::Frame, packer::Packer, rect::Rect, texture_packer_config::TexturePackerConfig};
+use std::cmp::max;
 
 struct Skyline {
     pub x: u32,
@@ -25,18 +19,16 @@ impl Skyline {
     }
 }
 
-pub struct SkylinePacker<P: Pixel> {
+pub struct SkylinePacker {
     config: TexturePackerConfig,
     border: Rect,
 
     // the skylines are sorted by their `x` position
     skylines: Vec<Skyline>,
-
-    phantom_data: PhantomData<P>,
 }
 
-impl<P: Pixel> SkylinePacker<P> {
-    pub fn new(config: TexturePackerConfig) -> SkylinePacker<P> {
+impl SkylinePacker {
+    pub fn new(config: TexturePackerConfig) -> Self {
         let mut skylines = Vec::new();
         skylines.push(Skyline {
             x: 0,
@@ -48,7 +40,6 @@ impl<P: Pixel> SkylinePacker<P> {
             config,
             border: Rect::new(0, 0, config.max_width, config.max_height),
             skylines,
-            phantom_data: PhantomData,
         }
     }
 
@@ -151,12 +142,10 @@ impl<P: Pixel> SkylinePacker<P> {
     }
 }
 
-impl<P: Pixel> Packer for SkylinePacker<P> {
-    type Pixel = P;
-
-    fn pack(&mut self, key: String, texture: &dyn Texture<Pixel = P>) -> Option<Frame> {
-        let mut width = texture.width();
-        let mut height = texture.height();
+impl Packer for SkylinePacker {
+    fn pack(&mut self, key: String, texture_rect: &Rect) -> Option<Frame> {
+        let mut width = texture_rect.w;
+        let mut height = texture_rect.h;
 
         width += self.config.texture_padding;
         height += self.config.texture_padding;
@@ -178,8 +167,8 @@ impl<P: Pixel> Packer for SkylinePacker<P> {
                 source: Rect {
                     x: 0,
                     y: 0,
-                    w: texture.width(),
-                    h: texture.height(),
+                    w: texture_rect.w,
+                    h: texture_rect.h,
                 },
             })
         } else {
@@ -187,10 +176,10 @@ impl<P: Pixel> Packer for SkylinePacker<P> {
         }
     }
 
-    fn can_pack(&self, texture: &dyn Texture<Pixel = P>) -> bool {
+    fn can_pack(&self, texture_rect: &Rect) -> bool {
         if let Some((_, rect)) = self.find_skyline(
-            texture.width() + self.config.texture_padding,
-            texture.height() + self.config.texture_padding,
+            texture_rect.w + self.config.texture_padding,
+            texture_rect.h + self.config.texture_padding,
         ) {
             let skyline = Skyline {
                 x: rect.left(),

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -1,3 +1,5 @@
+use crate::texture::Texture;
+
 /// Defines a rectangle in pixels with the origin at the top-left of the texture atlas.
 #[derive(Copy, Clone, Debug)]
 pub struct Rect {
@@ -148,5 +150,16 @@ impl Rect {
         }
 
         result
+    }
+}
+
+impl<T: Texture> From<&T> for Rect {
+    fn from(item: &T) -> Self {
+        Rect {
+            x: 0,
+            y: 0,
+            w: item.width(),
+            h: item.height(),
+        }
     }
 }


### PR DESCRIPTION
A packer is typically something that just places rectangles, and so
should not (and does not) care about the pixel format of the item being
packed.

This patch is the first step on resolving issue #56 