### PR TITLE
Implemented texture extrusion feature.

### DIFF
--- a/src/multi_texture_packer.rs
+++ b/src/multi_texture_packer.rs
@@ -71,6 +71,7 @@ mod tests {
             allow_rotation: false,
             border_padding: 0,
             texture_padding: 0,
+            texture_extrusion: 0,
             trim: false,
             texture_outlines: false,
         };

--- a/src/packer/skyline_packer.rs
+++ b/src/packer/skyline_packer.rs
@@ -143,8 +143,8 @@ impl Packer for SkylinePacker {
         let mut width = texture_rect.w;
         let mut height = texture_rect.h;
 
-        width += self.config.texture_padding;
-        height += self.config.texture_padding;
+        width += self.config.texture_padding + self.config.texture_extrusion * 2;
+        height += self.config.texture_padding + self.config.texture_extrusion * 2;
 
         if let Some((i, mut rect)) = self.find_skyline(width, height) {
             self.split(i, &rect);
@@ -152,8 +152,8 @@ impl Packer for SkylinePacker {
 
             let rotated = width != rect.w;
 
-            rect.w -= self.config.texture_padding;
-            rect.h -= self.config.texture_padding;
+            rect.w -= self.config.texture_padding + self.config.texture_extrusion * 2;
+            rect.h -= self.config.texture_padding + self.config.texture_extrusion * 2;
 
             Some(Frame {
                 key,
@@ -174,8 +174,8 @@ impl Packer for SkylinePacker {
 
     fn can_pack(&self, texture_rect: &Rect) -> bool {
         if let Some((_, rect)) = self.find_skyline(
-            texture_rect.w + self.config.texture_padding,
-            texture_rect.h + self.config.texture_padding,
+            texture_rect.w + self.config.texture_padding + self.config.texture_extrusion * 2,
+            texture_rect.h + self.config.texture_padding + self.config.texture_extrusion * 2,
         ) {
             let skyline = Skyline {
                 x: rect.left(),

--- a/src/texture_packer_config.rs
+++ b/src/texture_packer_config.rs
@@ -21,6 +21,8 @@ pub struct TexturePackerConfig {
     pub border_padding: u32,
     /// Size of the padding between frames in pixel. Default value is `2`
     pub texture_padding: u32,
+    /// Size of the repeated pixels at the border of each image. Default value is `0`.
+    pub texture_extrusion: u32,
 
     /// True to trim the empty pixels of the input images. Default value is `true`.
     pub trim: bool,
@@ -39,6 +41,7 @@ impl Default for TexturePackerConfig {
 
             border_padding: 0,
             texture_padding: 2,
+            texture_extrusion: 0,
 
             trim: true,
 


### PR DESCRIPTION
This is an implementation of texture extrusion like what's available in the TexturePacker. You can see their explanation of the feature here: https://www.codeandweb.com/texturepacker/documentation/texture-settings Press Ctrl+F and search for "extrude" to find the illustration.

I can also demonstrate why this is a useful feature with one of my own projects by showing two of the same screenshot with a different algorithm: https://imgur.com/a/aQedHmh Notice the ugly seams in the original at the top, lessened dramatically in the new version at the bottom.

What I believe is happening here is that the bilinear filtering doesn't know what to do with the edge of a tile. It sees a zeroed-out pixel right next to a colored pixel so it blends them together and the result is subtle discoloration at the edge of what gets rendered to the frame buffer. Usually it's hard to see but when solidly colored tiles are right next to each other it becomes much less subtle. Adding extra colored pixels around the edges tells the bilinear filter to just blend the original color with more of itself, thus fixing much of the issue.

