### PR TITLE
Allow the key to be generic rather than only limited to `String`.

### DIFF
--- a/src/frame.rs
+++ b/src/frame.rs
@@ -2,9 +2,9 @@ use crate::rect::Rect;
 
 /// Boundaries and properties of a packed texture.
 #[derive(Clone, Debug)]
-pub struct Frame {
+pub struct Frame<K> {
     /// Key used to uniquely identify this frame.
-    pub key: String,
+    pub key: K,
     /// Rectangle describing the texture coordinates and size.
     pub frame: Rect,
     /// True if the texture was rotated during packing. 

--- a/src/packer/mod.rs
+++ b/src/packer/mod.rs
@@ -4,7 +4,7 @@ pub use self::skyline_packer::SkylinePacker;
 
 mod skyline_packer;
 
-pub trait Packer {
-    fn pack(&mut self, key: String, texture_rect: &Rect) -> Option<Frame>;
+pub trait Packer<K> {
+    fn pack(&mut self, key: K, texture_rect: &Rect) -> Option<Frame<K>>;
     fn can_pack(&self, texture_rect: &Rect) -> bool;
 }

--- a/src/packer/skyline_packer.rs
+++ b/src/packer/skyline_packer.rs
@@ -138,8 +138,8 @@ impl SkylinePacker {
     }
 }
 
-impl Packer for SkylinePacker {
-    fn pack(&mut self, key: String, texture_rect: &Rect) -> Option<Frame> {
+impl<K> Packer<K> for SkylinePacker {
+    fn pack(&mut self, key: K, texture_rect: &Rect) -> Option<Frame<K>> {
         let mut width = texture_rect.w;
         let mut height = texture_rect.h;
 


### PR DESCRIPTION
[This issue](https://github.com/PistonDevelopers/texture_packer/issues/48) was bothering me so I thought I'd raise a PR for it. Fairly simple change, just introduces the key as a generic parameter.