### PR TITLE
New feature: force output texture size / force max dimensions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "texture_packer"
-version = "0.25.0"
+version = "0.26.0"
 authors = ["Coeuvre <coeuvre@gmail.com>"]
 edition = "2018"
 keywords = ["texture", "packer", "piston"]

--- a/examples/packer-test.rs
+++ b/examples/packer-test.rs
@@ -22,6 +22,7 @@ fn main() {
         allow_rotation: false,
         texture_outlines: true,
         border_padding: 2,
+        force_max_dimensions: true,
         ..Default::default()
     };
 

--- a/examples/packer-test.rs
+++ b/examples/packer-test.rs
@@ -22,7 +22,7 @@ fn main() {
         allow_rotation: false,
         texture_outlines: true,
         border_padding: 2,
-        force_max_dimensions: true,
+        force_max_dimensions: false,
         ..Default::default()
     };
 

--- a/src/texture_packer.rs
+++ b/src/texture_packer.rs
@@ -146,6 +146,10 @@ where
     type Pixel = Pix;
 
     fn width(&self) -> u32 {
+        if self.config.force_max_dimensions {
+            return self.config.max_width
+        }
+
         let mut right = None;
 
         for (_, frame) in self.frames.iter() {
@@ -166,6 +170,10 @@ where
     }
 
     fn height(&self) -> u32 {
+        if self.config.force_max_dimensions {
+            return self.config.max_height
+        }
+
         let mut bottom = None;
 
         for (_, frame) in self.frames.iter() {

--- a/src/texture_packer_config.rs
+++ b/src/texture_packer_config.rs
@@ -14,6 +14,10 @@ pub struct TexturePackerConfig {
     /// rotated 90 degrees clockwise.
     pub allow_rotation: bool,
 
+    /// If enabled, the size of the output texture will always match [max_width] and [max_height]
+    /// leaving potentially much unused space on the texture.
+    pub force_max_dimensions: bool,
+
     //
     // texture configuration
     //
@@ -39,6 +43,7 @@ impl Default for TexturePackerConfig {
             max_height: 1024,
             allow_rotation: true,
 
+            force_max_dimensions: false,
             border_padding: 0,
             texture_padding: 2,
             texture_extrusion: 0,


### PR DESCRIPTION
This PR allows users to configure the exporter so that the output file's dimensions match the sizes of `TexturePackerConfig`'s `max_width` and `max_height` values. The name of the flag is `force_max_dimensions`.

Related issue: https://github.com/PistonDevelopers/texture_packer/issues/88